### PR TITLE
prove `commute a (f b) → commute a (f b⁻¹)`

### DIFF
--- a/src/algebra/commute.lean
+++ b/src/algebra/commute.lean
@@ -66,6 +66,30 @@ by { dsimp [commute], rw [one_mul, mul_one] }
 
 theorem commute.one_left (a : M) : commute 1 a := (commute.one a).symm
 
+section
+
+open is_monoid_hom (map_mul map_one)
+
+theorem commute.inv_hom {G : Type*} [group G] {f : G → M} [is_monoid_hom f]
+  {a : M} {b : G} (h : commute a (f b)) : commute a (f b⁻¹) :=
+calc a * (f b⁻¹) = (f b⁻¹) * (f b * a) * (f b⁻¹) : by rw [← mul_assoc, ← map_mul f, mul_left_inv, map_one f, one_mul]
+             ... = (f b⁻¹) * a                   : by rw [h.eq.symm, mul_assoc, mul_assoc a, ← map_mul f, mul_right_inv, map_one f, mul_one]
+
+theorem commute.inv_hom_left {G : Type*} [group G] {f : G → M} [is_monoid_hom f]
+  {a : G} {b : M} (h : commute (f a) b) : commute (f a⁻¹) b :=
+h.symm.inv_hom.symm
+
+theorem commute.inv_hom_inv_hom {G₁ : Type*} [group G₁] {f₁ : G₁ → M} [is_monoid_hom f₁]
+  {G₂ : Type*} [group G₂] {f₂ : G₂ → M} [is_monoid_hom f₂]
+  {a : G₁} {b : G₂} (h : commute (f₁ a) (f₂ b)) : commute (f₁ a⁻¹) (f₂ b⁻¹) :=
+h.inv_hom.inv_hom_left
+
+end
+
+theorem commute.inv_units {a : M} {b : units M} (h : commute a ↑b) : commute a ↑b⁻¹ := h.inv_hom
+
+theorem commute.inv_units_left {a : units M} {b : M} (h : commute ↑a b) : commute ↑a⁻¹ b := h.inv_hom_left
+
 theorem commute.pow {a b : M} (hab : commute a b) : ∀ (n : ℕ), commute a (b ^ n)
 | 0 := by { rw [pow_zero], exact commute.one a }
 | (n + 1) := by { rw [pow_succ], exact hab.mul (commute.pow n) }
@@ -109,11 +133,7 @@ section group
 variables {G : Type*} [group G]
 
 theorem commute.inv {a b : G} (hab : commute a b) : commute a b⁻¹ :=
-begin
-  dsimp [commute] at *,
-  symmetry, apply eq_mul_inv_iff_mul_eq.mpr,
-  rw [mul_assoc, hab, ← mul_assoc, inv_mul_self, one_mul]
-end
+@commute.inv_hom _ _ _ _ id _ a b hab
 
 theorem commute.inv_left {a b : G} (hab : commute a b) : commute a⁻¹ b :=
 hab.symm.inv.symm

--- a/src/algebra/commute.lean
+++ b/src/algebra/commute.lean
@@ -16,7 +16,7 @@ so for rewriting we need syntax like `rw [(hb.pow_left 5).eq]`
 rather than just `rw [hb.pow_left 5]`.
 -/
 
-import algebra.group_power
+import data.set.basic algebra.group_power
   group_theory.submonoid group_theory.subgroup
   ring_theory.subring
 
@@ -117,6 +117,20 @@ instance centralizer.is_submonoid (a : M) : is_submonoid (centralizer a) :=
 instance set_centralizer.is_submonoid (S : set M) : is_submonoid (set_centralizer S) :=
 { one_mem := λ a h, commute.one a,
   mul_mem := λ x y hx hy a h, (hx a h).mul (hy a h) }
+
+/-- Given a homomogrphism from a group `G` to a monoid `M`, and an element `a ∈ M`,
+the preimage of the centralizer of `a` under `f` is a subgroup of `G`. -/
+instance centralizer.preimage_is_subgroup
+  (a : M) {G : Type*} [group G] (f : G → M) [is_monoid_hom f]
+  : is_subgroup (f⁻¹' (centralizer a)) :=
+{ inv_mem := λ b (hb : commute a (f b)), hb.inv_hom }
+
+/-- Given a homomogrphism from a group `G` to a monoid `M`, and a subset `S ⊆ M`,
+the preimage of the centralizer of `S` under `f` is a subgroup of `G`. -/
+instance set_centralizer.preimage_is_subgroup (S : set M)
+  {G : Type*} [group G] (f : G → M) [is_monoid_hom f]
+  : is_subgroup (f⁻¹' (set_centralizer S)) :=
+{ inv_mem := λ b (hb : ∀ a ∈ S, commute a (f b)) a ha, (hb a ha).inv_hom }
 
 end monoid
 


### PR DESCRIPTION
This is a more general version of `commute.inv` that is usable, e.g.,
for the case if only `b` is invertible.

Hi, these are theorems I mentioned in my comment to your pull request. I need them in case `M=opposite (End α)`, `units M ≃ equiv.perm α` for some dynamical systems stuff I'm going to submit in a few days. Feel free to adjust to your taste.